### PR TITLE
circleciでcomposer installの時間をキャッシュ保存で短縮する

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,13 @@ jobs:
       - image: circleci/php:7.3-node-browsers
     steps:
       - checkout
+      - restore_cache:
+       key: composer-v1-{{ checksum "composer.lock" }}
       - run: composer install -n --prefer-dist
+      - save_cache:
+       key: composer-v1-{{ checksum "composer.lock" }}
+       paths:
+         - vendor
       - run: sudo apt-get install build-essential libpng-dev
       - run: npm ci
       - run: npm run dev

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,13 +6,13 @@ jobs:
     steps:
       - checkout
       - restore_cache:
-       key: composer-v1-{{ checksum "composer.lock" }}
+          key: composer-v1-{{ checksum "composer.lock" }}
       - run: composer install -n --prefer-dist
       - save_cache:
-       key: composer-v1-{{ checksum "composer.lock" }}
-       paths:
-         - vendor
-      - run: sudo apt-get install build-essential libpng-dev
+          key: composer-v1-{{ checksum "composer.lock" }}
+          paths:
+            - vendor
+　　　 - run: sudo apt-get install build-essential libpng-dev
       - run: npm ci
       - run: npm run dev
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,7 +12,7 @@ jobs:
           key: composer-v1-{{ checksum "composer.lock" }}
           paths:
             - vendor
-　　　 - run: sudo apt-get install build-essential libpng-dev
+      - run: sudo apt-get install build-essential libpng-dev
       - run: npm ci
       - run: npm run dev
       - run:


### PR DESCRIPTION
composerのキャッシュ